### PR TITLE
Add swarm and proxy functionality to hyperproxy node.

### DIFF
--- a/packages/hyperproxy-browser/src/index.js
+++ b/packages/hyperproxy-browser/src/index.js
@@ -29,6 +29,9 @@ function init() {
         document.querySelector('#send').disabled = false;
 
         client.hub.subscribe(activeHash).on('data', ({sender, message}) => {
+
+            // TODO: Remove this commented out code @lgvichy https://github.com/goonism/hyperproxy/issues/7
+            // console.log(Buffer.from(message).toString('utf8'));
             dataListEl.appendChild(createElement(`
                 <li>${sender} @ ${shortHash} : ${message}</li>
             `));

--- a/packages/hyperproxy-hub-client/src/index.js
+++ b/packages/hyperproxy-hub-client/src/index.js
@@ -5,8 +5,8 @@ import {HUB_NAME, HUB_URL} from 'hyperproxy-config';
 
 export default class HyperproxyHubClient {
 
-    constructor(wrtc = null, name = HUB_NAME, url = HUB_URL) {
-        this.hub = signalhub(name, [url]);
+    constructor(wsClass, wrtc = null, name = HUB_NAME, url = HUB_URL) {
+        this.hub = signalhub(name, [url], wsClass);
         this.swarm = wrtc
             ? swarm(this.hub, {wrtc})
             : swarm(this.hub);


### PR DESCRIPTION


| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  #6 
| Patch: Bug Fix?          | N
| Major: Breaking Change?  | Y
| Minor: New Feature?      | Y
| Tests Added + Pass?      | Nope :) 
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | N
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Adds swarm functionality to the HyperProxy node. This makes it possible for a browser using WebRTC to fetch any native Dat-node files it wants! :D 